### PR TITLE
"waii-sdk-js" dependency version fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "waii-cli",
-  "version": "1.28.1",
+  "version": "1.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "waii-cli",
-      "version": "1.28.1",
+      "version": "1.30.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/js-beautify": "^1.14.1",
@@ -17,7 +17,7 @@
         "ts-node": "^10.9.1",
         "uri-js": "^4.4.1",
         "uuid": "^9.0.0",
-        "waii-sdk-js": "^1.27.3",
+        "waii-sdk-js": "1.28.3-beta.12",
         "yaml": "^2.3.1"
       },
       "bin": {
@@ -940,9 +940,9 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
     },
     "node_modules/waii-sdk-js": {
-      "version": "1.27.3",
-      "resolved": "https://registry.npmjs.org/waii-sdk-js/-/waii-sdk-js-1.27.3.tgz",
-      "integrity": "sha512-se6ms5et6HywyqXwpfl3jlTxLetRIO2AyXgN4WS6ubDG487yxB8enbWUgmw6ZIpwC2e9S+B8JujfFcargvknWA==",
+      "version": "1.28.3-beta.12",
+      "resolved": "https://registry.npmjs.org/waii-sdk-js/-/waii-sdk-js-1.28.3-beta.12.tgz",
+      "integrity": "sha512-Snru3mVVHiYbXhXFwVkqBvLPb5x4O5ORCy5dCKNNRyDfLjxyKtb9w6IkklOHpJDZTE6ixGfhluHPmlfUHP/GZA==",
       "license": "Apache-2.0",
       "dependencies": {
         "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ts-node": "^10.9.1",
     "uri-js": "^4.4.1",
     "uuid": "^9.0.0",
-    "waii-sdk-js": "^1.28.3",
+    "waii-sdk-js": "1.28.3-beta.12",
     "yaml": "^2.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
### What happened?
- I accidentally pushed the changes last week that resulted in build fail. It was fixed in 1.30 branch but not in main
- The SDK version 1.28.3 is not published yet (1.28.3-beta-* < 1.28.3), so this PR is changing it back to exact published version